### PR TITLE
Feature/make scorer less naive

### DIFF
--- a/lib_scorer/pcfg_password_scorer.py
+++ b/lib_scorer/pcfg_password_scorer.py
@@ -204,7 +204,9 @@ class PCFGPasswordScorer:
         # Start out at 100% probability
         cur_prob = 1.0
 
-        # I
+        # Underneath is an implementation of the password scorer where
+        # if a segment has not been trained on, it will get the lowest
+        # probability of that category instead of 0.
 
         for item in found_walks:
             cur_prob *= get_probability(item, self.count_keyboard)

--- a/lib_scorer/pcfg_password_scorer.py
+++ b/lib_scorer/pcfg_password_scorer.py
@@ -215,7 +215,7 @@ class PCFGPasswordScorer:
         for item in found_years:
             cur_prob *= self.count_years.get(item, min_prob_years)
 
-        min_prob_context_sensitive = min(self.count_context_sensitive)
+        min_prob_context_sensitive = min(self.count_context_sensitive.values())
         for item in found_context_sensitive_strings:
             cur_prob *= self.count_context_sensitive.get(item, min_prob_context_sensitive)
 
@@ -231,7 +231,7 @@ class PCFGPasswordScorer:
         for item in found_other_strings:
             cur_prob *= get_probability(item, self.count_other)
 
-        min_prob_base_structures = min(self.count_base_structures)
+        min_prob_base_structures = min(self.count_base_structures.values())
         cur_prob *= self.count_base_structures.get(base_structure, min_prob_base_structures)
 
         # Classify it as a password if the probablility is higher than the

--- a/lib_scorer/pcfg_password_scorer.py
+++ b/lib_scorer/pcfg_password_scorer.py
@@ -231,7 +231,8 @@ class PCFGPasswordScorer:
         for item in found_other_strings:
             cur_prob *= get_probability(item, self.count_other)
 
-        cur_prob *= self.count_base_structures[base_structure]
+        min_prob_base_structures = min(self.count_base_structures)
+        cur_prob *= self.count_base_structures.get(base_structure, min_prob_base_structures)
 
         # Classify it as a password if the probablility is higher than the
         # PCFG cut-off limit OR the OMEN score is equal to or below the OMEN


### PR DESCRIPTION
Create a custom implementation of the password-scorer where a term will not get a probability of 0 when it was not trained on, but the lowest probability that is available in that category. 